### PR TITLE
Fixes auto-index-creation

### DIFF
--- a/backendserver/src/main/java/mariomonday/backend/AppConfig.java
+++ b/backendserver/src/main/java/mariomonday/backend/AppConfig.java
@@ -35,14 +35,4 @@ public class AppConfig {
   public AbstractEloManager eloManager() {
     return new IndifferentEloManager();
   }
-
-  @Bean
-  MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
-    return new MongoTransactionManager(dbFactory);
-  }
-
-  @Bean
-  MongoTemplate mongoTemplate(MongoDatabaseFactory dbFactory) {
-    return new MongoTemplate(dbFactory);
-  }
 }


### PR DESCRIPTION
Fixes issue with index not being created for issue #87 . Added additional note in #71 to make sure this doesn't happen again.

This was caused because we were using the default mongo factory in java to create our mongo client. This would then override the values set in application.properties, resulting in the index not being created since auto-index-creation defaults to false. If we delete the bean in Java, spring will automatically pull from the application.properties file to create the correct client that has auto-index-creation set to true.